### PR TITLE
forward the arguments in quotes to ensure a proper forwarding

### DIFF
--- a/webfrontend/htmlauth/start.sh
+++ b/webfrontend/htmlauth/start.sh
@@ -120,7 +120,7 @@ if [ ! -z "$ORIGINALSCRIPTPARAMS" ]; then
 
 	echo "Lötzimmer Original-Script verwenden..."
 	echo "Aufrufparameter: $ORIGINALSCRIPTPARAMS"
-	sh ./alexa_remote_control.sh $ORIGINALSCRIPTPARAMS
+	sh ./alexa_remote_control.sh "$@"
 	exit 0
 
 fi


### PR DESCRIPTION
Hey Christian,

Ich wollte TTS für Gruppen Benutzen und habe rausgefunden, dass man das original script leider nicht mit leerzeichen nutzen kann.
Ich hatte probiert TTS selbst mit `?original&-e=speak:'hallo welt'` aufzurufen und das script hatte sich dann beschwert, dass `welt` kein valider Parameter ist.

Jegliche versuche mit single oder Double quotes blieb erfolglos. Hab das `start.sh` script dann debuggt und rausgefunden, dass man das direkt mit "$@" aufrufen sollte. Dann werden die Parameter korrekt übergeben. Dann steht zwar alles in double quotes, aber es geht wenigsten.

Wär cool, wenn du das Releasen könntest :)