### PR TITLE
Allow groups for TTS

### DIFF
--- a/webfrontend/htmlauth/tts.php
+++ b/webfrontend/htmlauth/tts.php
@@ -97,7 +97,7 @@ if ( !isset($devicelist) or !isset($devicelist->devices) ) {
 }
 
 $realDeviceNames = array( );
-$allowedDevices = array ("ECHO", "KNIGHT", "ROOK");
+$allowedDevices = array ("ECHO", "KNIGHT", "ROOK", "WHA");
 
 $deviceparamCount = count($devices);
 echo "Number of device params: $deviceparamCount\n";


### PR DESCRIPTION
Hallo Christian,

Im selben Zuge, könnte man doch TTS auch für Gruppen erlauben. Hab jetzt keine Recherche gemacht, was WHA bedeutet, aber alle meine Gruppen sind als Typ "WHA" eingetragen.

Alternativ, kann man Gruppen nutzen, wenn PR-19 gemerged ist.

Aktuell gibt es keine Möglichkeit einen Text via TTS an eine Gruppe zu schicken.

Wäre cool, wenn das Einzug findet :)